### PR TITLE
Removed alert messages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,6 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
     <div class="container">
       <%= yield %>
     </div>


### PR DESCRIPTION
Removed alert messages

They were at the top of our application.html.erb file and messing up the layout...this conflicts with the positioning of especially the navbar. Alert messages will be added back in later. Ticket created for adding the alerts back in #60 

![screen shot 2017-03-30 at 11 49 44](https://cloud.githubusercontent.com/assets/22404695/24499579/7b537648-1542-11e7-9ed1-e7a0154ed62e.png)
